### PR TITLE
Added missing pgsql installation file

### DIFF
--- a/conf/install_pgsql.sql
+++ b/conf/install_pgsql.sql
@@ -1,0 +1,10 @@
+create table comments (
+	id serial not null primary key,
+	identifier character(72) not null,
+	"user" integer not null,
+	status integer not null,
+	ts timestamp not null,
+	"comment" text not null
+);
+create index identifier on comments (identifier, status, ts);
+create index "user" on comments ("user", status, ts);


### PR DESCRIPTION
Tried to install the comments app using postgres and failed.
Converted the mysql install sql file to pgsql format.
90% sure the indexes are setup correctly for postgres (it showed to be installed correctly when used).
